### PR TITLE
feat: add appreciations table migration

### DIFF
--- a/comgeneratorV2/supabase/migrations/20250803085614_create_appreciations.sql
+++ b/comgeneratorV2/supabase/migrations/20250803085614_create_appreciations.sql
@@ -1,0 +1,42 @@
+/*
+  # Création de la table appreciations
+
+  1. Table
+    - id uuid PK
+    - user_id uuid
+    - detailed text
+    - summary text
+    - tag text
+    - created_at timestamptz
+
+  2. Sécurité
+    - Activation de RLS
+    - Policies SELECT/INSERT limitées à auth.uid() = user_id
+*/
+
+-- Création de la table
+CREATE TABLE IF NOT EXISTS appreciations (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id uuid REFERENCES auth.users(id) ON DELETE CASCADE,
+  detailed text,
+  summary text,
+  tag text,
+  created_at timestamptz DEFAULT now()
+);
+
+-- Activation de RLS
+ALTER TABLE appreciations ENABLE ROW LEVEL SECURITY;
+
+-- Policy pour SELECT
+CREATE POLICY "Users can view their own appreciations"
+  ON appreciations
+  FOR SELECT
+  TO authenticated
+  USING (auth.uid() = user_id);
+
+-- Policy pour INSERT
+CREATE POLICY "Users can create their own appreciations"
+  ON appreciations
+  FOR INSERT
+  TO authenticated
+  WITH CHECK (auth.uid() = user_id);


### PR DESCRIPTION
## Summary
- add `appreciations` table to store user feedback
- enforce RLS with SELECT and INSERT policies

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_688f23d97828832fb362e375d0ef10d0