### PR TITLE
Add appreciation types and table

### DIFF
--- a/comgeneratorV2/src/lib/database.types.ts
+++ b/comgeneratorV2/src/lib/database.types.ts
@@ -101,6 +101,29 @@ export interface Database {
           created_at?: string;
         };
       };
+      appreciations: {
+        Row: {
+          id: string;
+          detailed: string;
+          summary: string;
+          tag: 'tres_bien' | 'bien' | 'moyen' | 'insuffisant';
+          created_at: string;
+        };
+        Insert: {
+          id?: string;
+          detailed: string;
+          summary: string;
+          tag: 'tres_bien' | 'bien' | 'moyen' | 'insuffisant';
+          created_at?: string;
+        };
+        Update: {
+          id?: string;
+          detailed?: string;
+          summary?: string;
+          tag?: 'tres_bien' | 'bien' | 'moyen' | 'insuffisant';
+          created_at?: string;
+        };
+      };
     };
   };
 }

--- a/comgeneratorV2/src/lib/types.ts
+++ b/comgeneratorV2/src/lib/types.ts
@@ -23,6 +23,8 @@ export interface AppreciationResult {
 
 export type AppreciationTone = 'bienveillant' | 'normal' | 'severe';
 
+export type AppreciationTag = 'tres_bien' | 'bien' | 'moyen' | 'insuffisant';
+
 export interface AppreciationFormFields {
   subject: string;
   studentName: string;
@@ -36,6 +38,14 @@ export interface AppreciationFormFields {
   minLength: number;
   maxLength: number;
   tone: AppreciationTone;
+}
+
+export interface SavedAppreciation {
+  id: string;
+  detailed: string;
+  summary: string;
+  tag: AppreciationTag;
+  createdAt: string;
 }
 
 export interface Article {


### PR DESCRIPTION
## Summary
- define `AppreciationTag` and `SavedAppreciation` types
- register `appreciations` table in Supabase database types

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688f2499ae84832fa4f7d0ed9392bde4