### PR TITLE
feat: allow tagging appreciations

### DIFF
--- a/comgeneratorV2/src/lib/database.types.ts
+++ b/comgeneratorV2/src/lib/database.types.ts
@@ -101,6 +101,32 @@ export interface Database {
           created_at?: string;
         };
       };
+      appreciations: {
+        Row: {
+          id: string;
+          user_id: string;
+          detailed: string;
+          summary: string;
+          tag: string;
+          created_at: string;
+        };
+        Insert: {
+          id?: string;
+          user_id: string;
+          detailed: string;
+          summary: string;
+          tag: string;
+          created_at?: string;
+        };
+        Update: {
+          id?: string;
+          user_id?: string;
+          detailed?: string;
+          summary?: string;
+          tag?: string;
+          created_at?: string;
+        };
+      };
     };
   };
 }


### PR DESCRIPTION
## Summary
- enable saving appreciations with context menu tagging and confirmation modal
- add appreciations table to typed database schema

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688f25fc8e78832fa91fd22cd8c79a1f