### PR TITLE
feat: ajout d'une fonction ping (keep-alive) pour Supabase

### DIFF
--- a/.github/workflows/supabase-keepalive.yml
+++ b/.github/workflows/supabase-keepalive.yml
@@ -1,0 +1,57 @@
+name: Supabase Keep-Alive
+
+# =====================================================
+# Empêche la mise en pause automatique du projet Supabase
+# (plan gratuit : pause après ~7 jours d'inactivité).
+#
+# Ce workflow appelle l'Edge Function "ping" qui effectue
+# une requête minimale en lecture seule sur la base, ce qui
+# génère l'activité nécessaire pour garder le projet actif.
+#
+# Prérequis : définir 2 secrets de dépôt (Settings > Secrets
+# and variables > Actions) :
+#   - SUPABASE_URL       ex: https://xxxxxxxx.supabase.co
+#   - SUPABASE_ANON_KEY  la clé "anon" publique du projet
+# =====================================================
+
+on:
+  schedule:
+    # Tous les jours à 04:17 UTC (marge confortable < 7 jours).
+    # Minute non nulle pour éviter la congestion des runs à l'heure pile.
+    - cron: '17 4 * * *'
+  # Permet de lancer le ping manuellement depuis l'onglet Actions.
+  workflow_dispatch:
+
+jobs:
+  ping:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Ping Supabase Edge Function
+        env:
+          SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+          SUPABASE_ANON_KEY: ${{ secrets.SUPABASE_ANON_KEY }}
+        run: |
+          if [ -z "$SUPABASE_URL" ] || [ -z "$SUPABASE_ANON_KEY" ]; then
+            echo "::error::Les secrets SUPABASE_URL et SUPABASE_ANON_KEY doivent être définis."
+            exit 1
+          fi
+
+          echo "Appel de l'Edge Function ping..."
+          HTTP_CODE=$(curl -sS -o /tmp/ping_response.json -w "%{http_code}" \
+            --retry 3 --retry-delay 5 --max-time 30 \
+            -X POST "${SUPABASE_URL}/functions/v1/ping" \
+            -H "Authorization: Bearer ${SUPABASE_ANON_KEY}" \
+            -H "Content-Type: application/json")
+
+          echo "Code HTTP : $HTTP_CODE"
+          echo "Réponse :"
+          cat /tmp/ping_response.json || true
+          echo ""
+
+          if [ "$HTTP_CODE" -lt 200 ] || [ "$HTTP_CODE" -ge 300 ]; then
+            echo "::error::Le ping a échoué (HTTP $HTTP_CODE)."
+            exit 1
+          fi
+
+          echo "✅ Keep-alive Supabase réussi."

--- a/comgeneratorV2/supabase/functions/ping/index.ts
+++ b/comgeneratorV2/supabase/functions/ping/index.ts
@@ -1,0 +1,77 @@
+// supabase/functions/ping/index.ts
+// =====================================================
+// FONCTION "PING" / KEEP-ALIVE
+// -----------------------------------------------------
+// But : effectuer une requête minimale et sans effet de
+// bord sur la base de données afin de générer une
+// activité régulière et empêcher la mise en pause
+// automatique du projet Supabase (plan gratuit).
+//
+// - Aucune écriture : on fait juste un COUNT en mode
+//   "head" (ne ramène aucune ligne) sur une table stable.
+// - Déclenchée par un cron externe (GitHub Actions).
+// =====================================================
+
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2.39.7';
+
+// Headers CORS communs (alignés sur les autres fonctions du projet)
+const corsHeaders = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Methods': 'GET, POST, OPTIONS',
+  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
+};
+
+Deno.serve(async (req) => {
+  // CORS preflight
+  if (req.method === 'OPTIONS') {
+    return new Response(null, { status: 200, headers: corsHeaders });
+  }
+
+  try {
+    const supabaseUrl = Deno.env.get('SUPABASE_URL');
+    const supabaseServiceKey = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY');
+
+    if (!supabaseUrl || !supabaseServiceKey) {
+      console.error('[ping] Configuration serveur manquante');
+      return new Response(
+        JSON.stringify({ success: false, error: 'Configuration serveur manquante' }),
+        { status: 500, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+      );
+    }
+
+    const supabaseClient = createClient(supabaseUrl, supabaseServiceKey);
+
+    // Requête en lecture seule, ultra-légère : un COUNT "head"
+    // ne renvoie aucune ligne, juste de quoi solliciter la base.
+    const { error, count } = await supabaseClient
+      .from('profiles')
+      .select('*', { count: 'exact', head: true });
+
+    if (error) {
+      console.error('[ping] Erreur lors du keep-alive :', error.message);
+      return new Response(
+        JSON.stringify({ success: false, error: error.message }),
+        { status: 500, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+      );
+    }
+
+    const timestamp = new Date().toISOString();
+    console.log(`[ping] Keep-alive OK à ${timestamp} (profiles count: ${count ?? 'n/a'})`);
+
+    return new Response(
+      JSON.stringify({
+        success: true,
+        message: 'pong',
+        timestamp,
+        profiles_count: count ?? null,
+      }),
+      { status: 200, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+    );
+  } catch (err) {
+    console.error('[ping] Exception :', err);
+    return new Response(
+      JSON.stringify({ success: false, error: err?.message ?? String(err) }),
+      { status: 500, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+    );
+  }
+});


### PR DESCRIPTION
- Edge Function `ping` : requête COUNT en lecture seule sur `profiles` (aucune écriture, aucun effet de bord) pour générer de l'activité.
- Workflow GitHub Actions `supabase-keepalive` : appel quotidien de l'Edge Function pour éviter la mise en pause du projet (plan gratuit).
- Aucune modification du code existant : aucun risque de régression.


Claude-Session: https://claude.ai/code/session_01RDf3DxXpEez2xCChYyniPu